### PR TITLE
Use session cookie if the option is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.6
+go: 1.8
 
 script:
   - go test ./...

--- a/dynamostore/dynamostore.go
+++ b/dynamostore/dynamostore.go
@@ -51,6 +51,10 @@ type Store struct {
 
 	// Options is served as the default configuration for Cookie
 	Options *sessions.Options
+
+	// If UseSessionCookie is true, a cookie will not have Expires and Max-Age fields.
+	// Otherwise, it will be set to the same value of Options.MaxAge.
+	UseSessionCookie bool
 }
 
 // New returns a new session store.
@@ -103,13 +107,22 @@ func (s *Store) New(r *http.Request, name string) (*sessions.Session, error) {
 	return session, nil
 }
 
+func (s *Store) newCookie(name, value string, options *sessions.Options) *http.Cookie {
+	c := sessions.NewCookie(name, value, options)
+	if s.UseSessionCookie {
+		c.Expires = time.Time{}
+		c.MaxAge = 0
+	}
+	return c
+}
+
 // Save adds a single session to the response.
 func (s *Store) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
 	// Marked for deletion
 	if session.Options.MaxAge < 0 {
 		s.delete(session)
 		// Even we fail to delete, we should clear the cookie
-		http.SetCookie(w, sessions.NewCookie(session.Name(), "", session.Options))
+		http.SetCookie(w, s.newCookie(session.Name(), "", session.Options))
 		return nil
 	}
 
@@ -125,7 +138,7 @@ func (s *Store) Save(r *http.Request, w http.ResponseWriter, session *sessions.S
 	if err != nil {
 		return err
 	}
-	http.SetCookie(w, sessions.NewCookie(session.Name(), encoded, session.Options))
+	http.SetCookie(w, s.newCookie(session.Name(), encoded, session.Options))
 	return nil
 }
 

--- a/dynamostore/dynamostore.go
+++ b/dynamostore/dynamostore.go
@@ -49,7 +49,7 @@ type Store struct {
 	Table  *table.Table
 	Codecs []securecookie.Codec
 
-	// Option is served as the default configuration
+	// Options is served as the default configuration for Cookie
 	Options *sessions.Options
 }
 


### PR DESCRIPTION
```
=== RUN   TestUseSessionCookie
--- PASS: TestUseSessionCookie (0.19s)
=== RUN   TestStoreExpiration
--- PASS: TestStoreExpiration (3.27s)
=== RUN   TestStore
--- PASS: TestStore (0.20s)
=== RUN   TestStore_CustomType
--- PASS: TestStore_CustomType (0.17s)
PASS
ok      github.com/nabeken/gorilla-sessions-dynamodb/dynamostore        3.849s
```